### PR TITLE
CMake build for C++ examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.17)
-project(TIPL-cpp-examples VERSION 1.0.0 LANGUAGES CXX)
+project(TIPL-example VERSION 1.0.0 LANGUAGES CXX)
 include(CTest)
 find_package(TIPL REQUIRED)
 add_subdirectory(cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.17)
+project(TIPL-cpp-examples VERSION 1.0.0 LANGUAGES CXX)
+include(CTest)
+find_package(TIPL REQUIRED)
+add_subdirectory(cpp)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ A lot of the image processing libraries are designed for experimental/research p
 
 Now you can use TIPL
 
+### Building the C++ examples using CMake
+
+It is possible to install TIPL using CMake, in which case C++ packages using CMake can easily build with it. 
+In this package C++ examples are available in the `cpp` subdirectory. To build these using CMake:
+
+* Make sure TIPL is installed with CMake, e.g. in a directory called `<TIPL_install_directory>`  (see the TIPL README.md file how to do this).
+* Execute the commands from the root of your cloned `TIPL-example` directory:
+```bash$
+export CMAKE_PREFIX_PATH=<TIPL_install_directory>:$CMAKE_PREFIX_PATH
+mkdir build ; cd build
+cmake ..
+cmake --build .
+cd cpp
+```
+* At this point one should be able to execute the exmaple, e.g.:
+```bash$
+./linear_reg
+```
+* We also made a directory `cpp/TIPL-examples` and symbolic linked the source `data` directory there so that the exmaples can find their inputs.
+
+Naturally one can also locate the CMake TIPLConfig.cmake file using other CMake means than `CMAKE_PREFIX_PATH` e.g. by providing the CMake option: `-DTIPL_DIR=<TIPL_install_directory>/lib/cmake/TIPL` to cmake. One should also be able to build out of source (the `build` directory can really be anywhere). 
+
+Installation of the examples is not yet supported
+
 ## Example
 
 - Notebooks examples:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,8 @@
+foreach(prog load_nii linear_reg)
+  add_executable(${prog} "${prog}.cpp")
+  target_link_libraries(${prog} PUBLIC TIPL::tipl)
+  set_target_properties(${prog} PROPERTIES CXX_STANDARD 14)
+endforeach()
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TIPL-example)
+file(CREATE_LINK ${CMAKE_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/TIPL-example/data SYMBOLIC)


### PR DESCRIPTION
Added CMakeLists.txt to allow CMake building of the cpp examples (using a CMake installed TIPL)