### PR TITLE
Now works if TIPL is installed. Added option to enable CUDA build. Ex…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.17)
 project(TIPL-example VERSION 1.0.0 LANGUAGES CXX)
 include(CTest)
+option(ENABLE_CUDA "Enable using CUDA" OFF)
 find_package(TIPL REQUIRED)
 add_subdirectory(cpp)
+
+if( ENABLE_CUDA )
+add_subdirectory(cuda/image_linear_registration)
+add_subdirectory(cuda/image_resample)
+endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 foreach(prog load_nii linear_reg)
   add_executable(${prog} "${prog}.cpp")
   target_link_libraries(${prog} PUBLIC TIPL::tipl)
-  set_target_properties(${prog} PROPERTIES CXX_STANDARD 14)
+  set_target_properties(${prog} PROPERTIES CXX_STANDARD 17)
 endforeach()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TIPL-example)

--- a/cuda/image_linear_registration/CMakeLists.txt
+++ b/cuda/image_linear_registration/CMakeLists.txt
@@ -6,12 +6,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(CUDA REQUIRED)
 
-if(EXISTS "${TIPL_DIR}")
-    include_directories(${TIPL_DIR})
-else(EXISTS "${TIPL_DIR}")
-    find_package(TIPL REQUIRED)
-endif(EXISTS "${TIPL_DIR}")
-
 set(SOURCES
     linear_registration.cu)
 
@@ -22,5 +16,13 @@ set_target_properties(tipl_image_linear_registration PROPERTIES CXX_STANDARD 17 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler --extended-lambda")
 
 target_compile_definitions(tipl_image_linear_registration PUBLIC TIPL_USE_CUDA)
-target_link_libraries(tipl_image_linear_registration ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
+find_package(TIPL)
+if ( NOT TIPL_FOUND )
+  if(EXISTS "${TIPL_DIR}")
+    target_include_directories(tipl_image_linear_registration ${TIPL_DIR})
+  endif()
+else()
+  target_link_libraries(tipl_image_linear_registration TIPL::tipl)
+endif()
 
+target_link_libraries(tipl_image_linear_registration ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})

--- a/cuda/image_linear_registration/linear_registration.cu
+++ b/cuda/image_linear_registration/linear_registration.cu
@@ -1,4 +1,4 @@
-#include "tipl/tipl.hpp"
+#include "TIPL/tipl.hpp"
 #include <iostream>
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -35,7 +35,6 @@ int main(void)
 
     // 4: now use transformed image to calculate the transformation
     bool terminated = false;
-
     {
         // solve using cpu
         tipl::time t;
@@ -45,7 +44,6 @@ int main(void)
         std::cout << "cpu time (ms):" << t.elapsed<std::chrono::milliseconds>() << std::endl;
         std::cout << "cpu answer:\n" << answer << std::endl;
     }
-
     {
         // solve using gpu
         tipl::time t;

--- a/cuda/image_resample/CMakeLists.txt
+++ b/cuda/image_resample/CMakeLists.txt
@@ -6,12 +6,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(CUDA REQUIRED)
 
-if(EXISTS "${TIPL_DIR}")
-    include_directories(${TIPL_DIR})
-else(EXISTS "${TIPL_DIR}")
-    find_package(TIPL REQUIRED)
-endif(EXISTS "${TIPL_DIR}")
-
 set(SOURCES
     resample.cu)
 
@@ -22,5 +16,15 @@ set_target_properties(tipl_image_resample PROPERTIES CXX_STANDARD 17 CXX_EXTENSI
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -allow-unsupported-compiler --extended-lambda")
 
 target_compile_definitions(tipl_image_resample PUBLIC TIPL_USE_CUDA)
+
+find_package(TIPL)
+if ( NOT TIPL_FOUND )
+  if(EXISTS "${TIPL_DIR}")
+    target_include_directories(tipl_image_resample ${TIPL_DIR})
+  endif()
+else()
+  target_link_libraries(tipl_image_resample TIPL::tipl)
+endif()
+
 target_link_libraries(tipl_image_resample ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 

--- a/cuda/image_resample/resample.cu
+++ b/cuda/image_resample/resample.cu
@@ -1,4 +1,4 @@
-#include "tipl/tipl.hpp"
+#include "TIPL/tipl.hpp"
 #include <iostream>
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
Works with updated TIPL.
added:  -DENABLE_CUDA=OFF/ON CMake option to enable CUDA
in CUDA examples: 
   * changed `#include <tipl/tipl.hpp>` to `#include <TIPL/tipl.hpp> to match files in cpp/ directory
   * Changed CMake so that 
         *  Only use TIPL_DIR as the include path, if the package TIPL is not found. If the package TIPL is found, use the imported libraries (which should set the include path).

NB: Warning: Currently linear_resample did not build for me on summit (but linear_registration.cu did)